### PR TITLE
#fix/refractor: Network Resilience in deploy to Wordpress

### DIFF
--- a/apps/backend/src/entities/errors.ts
+++ b/apps/backend/src/entities/errors.ts
@@ -22,8 +22,8 @@ export class TranslationMissingError extends BaseError {}
 
 export class PortAlreadyInUseError extends BaseError {}
 
-export class VercelCliUnavailableError extends BaseError {}
-
 export class VercelInvalidTokenError extends BaseError {}
 
 export class NetworkUnavailableError extends BaseError {}
+
+export class WordpressInvalidTokenError extends BaseError {}

--- a/apps/backend/src/projects/projects-deploy-to-vercel.service.ts
+++ b/apps/backend/src/projects/projects-deploy-to-vercel.service.ts
@@ -55,6 +55,7 @@ export class ProjectsDeployToVercelService extends BaseService {
       'projects',
       'deploy-to-vercel',
     );
+
     await this.jobStatusesService.setAsStarted(jobStatus, {
       data: { token: data.token, name: data.projectName },
     });

--- a/apps/desktop/src/renderer/src/composables/useProjects.ts
+++ b/apps/desktop/src/renderer/src/composables/useProjects.ts
@@ -180,6 +180,8 @@ export function useProjects() {
         return 'Invalid WordPress Token';
       case 500:
         return 'Internal Server Error';
+      case 503:
+        return 'Network Error';
       default:
         return 'Unknown Error';
     }
@@ -199,6 +201,10 @@ export function useProjects() {
     switch (jobStatus?.errorCode) {
       case 403:
         return `Please check your WordPress Token or generate a new one.`;
+      case 500:
+        return `Something went wrong on our side. Please try again later.`;
+      case 503:
+        return `Network unavailable. Please check your connection and try again.`;
       default:
         return jobStatus?.errorStackTrace || '';
     }


### PR DESCRIPTION
> [!IMPORTANT]  
> Also, do we need to delete the created zips? like when we deploy we do create zips right these stay in disk 

- Added network resilience in deploy to wordpress
- Removed the schema check that was also handling axios request to verify token(matching Deploy to Vercel code)